### PR TITLE
Custom Construtor to handle WordPress Hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /node_modules/
+.phpcs.cache
 composer.lock

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -12,11 +12,12 @@ namespace BaseWpPlugin\Inc;
  */
 class Plugin {
 	/**
-	 * Hooks.
+	 * Custom constructor for handle WordPress Hooks
 	 */
-	public function __construct() {
+	public static function initialize() {
 
-		add_action( 'admin_notices', [ $this, 'display_hello_world' ] );
+		$self = new self();
+		add_action( 'admin_notices', [ $self, 'display_hello_world' ] );
 	}
 	/**
 	 * Display 'Hello from the Base WP Plugin!' message on admin panel
@@ -28,5 +29,7 @@ class Plugin {
 		</div>
 		<?php
 	}
+};
 
-}
+
+Plugin::initialize();

--- a/uninstall.php
+++ b/uninstall.php
@@ -7,7 +7,7 @@
 
 defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
-/** 
+/**
  * Access the database via SQL
 */
 global $wpdb;


### PR DESCRIPTION
update: custom contructor (named as **initalize** static method) to handle with the WordPress hooks, removing coupling from WordPress with the __constructor method && also updated: .gitignore